### PR TITLE
keep compatibility with 1.13

### DIFF
--- a/app/initializers/setup-sanitizers.js
+++ b/app/initializers/setup-sanitizers.js
@@ -4,6 +4,11 @@ export default {
   name: 'ember-sanitize-setup-sanitizers',
 
   initialize: function(container) {
-    container.registerOptionsForType('sanitizer', { instantiate: false });
+    if (container.registerOptionsForType) {
+      container.registerOptionsForType('sanitizer', { instantiate: false });
+    } else {
+      // Ember < 2
+      container.optionsForType('sanitizer', { instantiate: false });
+    }
   }
 };


### PR DESCRIPTION
Everything seems to work in 1.13 with this change. I think this is worth having as most people on old versions will up date to 1.13 before going to 2.0. Fixes #6
