### PR TITLE
Use getOwner instead of this.container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 ---
 language: node_js
+node_js:
+  - "4.1"
+  - "4.0"
+  - "0.12"
 
 sudo: false
 
@@ -9,7 +13,7 @@ cache:
 
 before_install:
   - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - "npm install -g npm"
 
 install:
   - npm install -g bower

--- a/addon/mixins/sanitize.js
+++ b/addon/mixins/sanitize.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { sanitize, sanitizeElement } from '../utils/sanitize';
+import getOwner from 'ember-getowner-polyfill';
 
 function loadConfig(container, name) {
   if (!name) { return; }
@@ -13,6 +14,6 @@ export default Ember.Mixin.create({
   },
 
   sanitizeHTML: function(html, configName) {
-    return sanitize(html, loadConfig(this.container, configName));
+    return sanitize(html, loadConfig(getOwner(this), configName));
   }
 });

--- a/app/helpers/sanitize-html.js
+++ b/app/helpers/sanitize-html.js
@@ -1,4 +1,5 @@
 import { sanitize } from 'ember-sanitize/utils/sanitize';
+import getOwner from 'ember-getowner-polyfill';
 import Ember from 'ember';
 
 export default Ember.Helper.extend({
@@ -6,7 +7,7 @@ export default Ember.Helper.extend({
     let config, configName = params[1];
     if (configName) {
       //lookup the config
-      config = this.container.lookup('sanitizer:' + configName);
+      config = getOwner(this).lookup('sanitizer:' + configName);
     }
 
     let sanitized = sanitize(params[0], config);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-getowner-polyfill": "~1.0.0",
     "ember-try": "0.0.6",
     "express": "^4.8.5",
     "glob": "^4.0.5"


### PR DESCRIPTION
`this.container` is deprecated, we should use `getOwner` instead. This change does this by including the `ember-getowner-polyfill` so it remains compatible with previous versions of Ember. I also made the tests run on newer versions of NodeJS, as 0.10 is horribly outdated (and some of the packages expect newer versions).
