### PR TITLE
Allow Addons to Depend on ember-sanitize

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,10 @@
 module.exports = {
   name: 'ember-sanitize',
 
-  included: function(app) {
-    this._super.included(app);
-    this.app.import('bower_components/sanitize.js/lib/sanitize.js');
+  included: function(app, parentAddon) {
+    var target = (parentAddon || app);
+    this._super.included(target);
+    target.import('bower_components/sanitize.js/lib/sanitize.js');
   }
 
 };


### PR DESCRIPTION
This changes the `index.js` `included` hook to match the pattern described in the ember-cli docs.

```
  included: function(app, parentAddon) {
    var target = (parentAddon || app);
    this._super.included(target);
    target.import('bower_components/sanitize.js/lib/sanitize.js');
  }
```

This allows the `ember-sanitize` addon to be a dependency of other addons.