### PR TITLE
Update getowner-pollyfill

### DIFF
--- a/addon/mixins/sanitize.js
+++ b/addon/mixins/sanitize.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { sanitize, sanitizeElement } from '../utils/sanitize';
-import getOwner from 'ember-getowner-polyfill';
+
+const {getOwner} = Ember;
 
 function loadConfig(container, name) {
   if (!name) { return; }

--- a/app/helpers/sanitize-html.js
+++ b/app/helpers/sanitize-html.js
@@ -1,6 +1,7 @@
 import { sanitize } from 'ember-sanitize/utils/sanitize';
-import getOwner from 'ember-getowner-polyfill';
 import Ember from 'ember';
+
+const {getOwner} = Ember;
 
 export default Ember.Helper.extend({
   compute(params) {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-getowner-polyfill": "^1.1.0"
+    "ember-getowner-polyfill": "^1.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Fixes the `ember-getowner-polyfill is now a true polyfill. Use Ember.getOwner directly instead of importing from ember-getowner-polyfill` deprecation.

It also seems travis is disabled?